### PR TITLE
trying chromedriver 2.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "chai-as-promised": "^6.0.0",
     "child-process-debug": "0.0.7",
     "chokidar": "^2.1.6",
-    "chromedriver": "^2.46.0",
+    "chromedriver": "^2.46",
     "colors": "1.1.2",
     "commander": "^2.20.0",
     "cucumber": "TheBrainFamily/cucumber-js#v1.3.0-chimp.7",


### PR DESCRIPTION
# Context:

While installing the latest version of chimpy in a new environment we have encountered the following issue:

```
[32m
Master Chimp and become a testing Ninja! Check out our course: [39m[4m[34mhttp://bit.ly/2btQaFu
[39m[24m
[33m
[chimp] Running...[39m
[selenium] Error: Could not download https://chromedriver.storage.googleapis.com/2.46.0/chromedriver_linux64.zip
    at Request.<anonymous> (/var/lib/jenkins/workspace/chimpy-project/node_modules/selenium-standalone/lib/install.js:373:21)
    at emitOne (events.js:96:13)
    at Request.emit (events.js:188:7)
    at Request.onRequestResponse (/var/lib/jenkins/workspace/chimpy-project/node_modules/request/request.js:1066:10)
    at emitOne (events.js:96:13)
    at ClientRequest.emit (events.js:188:7)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:478:21)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:99:23)
    at TLSSocket.socketOnData (_http_client.js:367:20)
    at emitOne (events.js:96:13)
    at TLSSocket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at TLSSocket.Readable.push (_stream_readable.js:134:10)
    at TLSWrap.onread (net.js:559:20)
Error: Could not download https://chromedriver.storage.googleapis.com/2.46.0/chromedriver_linux64.zip
    at Request.<anonymous> (/var/lib/jenkins/workspace/chimpy-project/node_modules/selenium-standalone/lib/install.js:373:21)
    at emitOne (events.js:96:13)
    at Request.emit (events.js:188:7)
    at Request.onRequestResponse (/var/lib/jenkins/workspace/chimpy-project/node_modules/request/request.js:1066:10)
    at emitOne (events.js:96:13)
    at ClientRequest.emit (events.js:188:7)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:478:21)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:99:23)
    at TLSSocket.socketOnData (_http_client.js:367:20)
    at emitOne (events.js:96:13)
    at TLSSocket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at TLSSocket.Readable.push (_stream_readable.js:134:10)
    at TLSWrap.onread (net.js:559:20)
Build step 'Execute shell' marked build as failure
```

The latest version of chimpy has been tested both in multiple OSX and Linux environments that resulted in the same error.

Changing the `chromedriver` dependency to `2.46` seem to do the trick

Note: this branch has been tested as follow, in `package.json`
```
{
// other fields
  "dependencies": {
    "chimpy": "mellmo/chimpy#fix/chromedriver.dependency"
  }
}
```