### PR TITLE
Change WebdriverIO API docs link version

### DIFF
--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -5,7 +5,7 @@ The following is a list of examples of how to do common tasks and assertions usi
 * Synchronous execution
 * Jasmine expectations
 
-*[Click here the full WebdriverIO API](http://webdriver.io/api.html)*
+*[Click here the full WebdriverIO API](http://v4.webdriver.io/api.html)*
 
 The variable `browser` is a handle to webdriver. It is shorthand for, or the equivalent of:
 


### PR DESCRIPTION
Changes WebdriverIO API docs link version to v4 in the Chimpy documentation.

Before this, the API referred in the documentation didn't match the actual API usable with Chimpy.