### PR TITLE
Added way of using babel.config.js in parent project along with chimpy

### DIFF
--- a/src/lib/babel-register.js
+++ b/src/lib/babel-register.js
@@ -1,5 +1,6 @@
 require('@babel/register')({
-  'presets': ['@babel/env']
+  'presets': ['@babel/env'],
+  'rootMode': 'upward-optional',
 });
 
 require('@babel/polyfill');


### PR DESCRIPTION
Otherwise babel.config.js is omitted by chimpy.