### PR TITLE
Fix for TheBrainFamily/chimpy#113

### DIFF
--- a/src/lib/cucumberjs/hooks.js
+++ b/src/lib/cucumberjs/hooks.js
@@ -107,8 +107,7 @@ module.exports = function hooks() {
     log.debug('[chimp][hooks] Forcibly exiting Cucumber');
 
     process.send(JSON.stringify(reason));
-    // Don't exit until the waitUntil uncaught promise bug is fixed in WebdriverIO
-    // exit(2);
+    exit(2);
   });
 
   process.on('SIGINT', () => {


### PR DESCRIPTION
I pulled this out into it's own fix because it's pretty devastating and keeps getting looked over because it's mixed with other questionable fixes. Without this fix, Chimpy will fail with a successful return code when Chrome exits abruptly, showing passing tests when in fact there's a big problem.