### PR TITLE
Adding inspect mode for Node >= 8.0

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -61,6 +61,7 @@ Use the `debugger;` statement in your code to create a breakpoints. You can plac
 
 ## 2. Tell Chimpy to start Cucumber in debug mode
 
+### In Node < 8.0
 You can use these command line switched to do that:
 
 ```shell
@@ -69,12 +70,29 @@ chimpy --debugCucumber
 chimpy --debugCucumber=<port>
 ```
 
-To debug mode and break on start:
+To turn on debug mode and break on start:
 
 ```shell
 chimpy --debugBrkCucumber
 # or
 chimpy --debugBrkCucumber=<port>
+```
+
+### In Node >= 8.0
+You can use these command line switched to do that:
+
+```shell
+chimpy --inspectCucumber
+# or
+chimpy --inspectCucumber=<port>
+```
+
+To turn on inspect mode and break on start:
+
+```shell
+chimpy --inspectBrkCucumber
+# or
+chimpy --inspectBrkCucumber=<port>
 ```
 
 You can then connect your favorite debugger and enjoy!
@@ -88,6 +106,7 @@ Use the `debugger;` statement in your code to create a breakpoints. You can plac
 
 ## 2. Tell Chimpy to start Mocha in debug mode
 
+### In Node < 8.0
 You can use these command line switched to do that:
 
 ```shell
@@ -102,6 +121,23 @@ To use debug mode and break on start use:
 chimpy --debugBrkMocha
 # or
 chimpy --debugBrkMocha=<port>
+```
+
+### In Node >= 8.0
+You can use these command line switched to do that:
+
+```shell
+chimpy --inspectMocha
+# or
+chimpy --inspectMocha=<port>
+```
+
+To turn on inspect mode and break on start:
+
+```shell
+chimpy --inspectBrkMocha
+# or
+chimpy --inspectBrkMocha=<port>
 ```
 
 #### *Want to become a testing Ninja?*

--- a/src/lib/cucumberjs/cucumber.js
+++ b/src/lib/cucumberjs/cucumber.js
@@ -60,6 +60,26 @@ class Cucumber {
       }
     }
 
+    if (this.options.inspectCucumber) {
+      port = parseInt(this.options.inspectCucumber);
+
+      if (port > 1) {
+        opts.execArgv = ['--inspect=' + port];
+      } else {
+        opts.execArgv = ['--inspect'];
+      }
+    }
+
+    if (this.options.inspectCucumberBrk) {
+      port = parseInt(this.options.inspectBrkCucumber);
+
+      if (port > 1) {
+        opts.execArgv = ['--inspect-brk=' + port];
+      } else {
+        opts.execArgv = ['--inspect-brk'];
+      }
+    }
+
     this.cucumberChild = cp.fork(path.join(__dirname, 'cucumber-wrapper.js'), args, opts);
 
     if (booleanHelper.isTruthy(this.options.conditionOutput)) {


### PR DESCRIPTION
This adds a new `--inspectCucumber` flag so we can use a debugger when using a modern version of Node. I'm on node 10.16.3, and I can't seem to debug at all using the old `--debugCucumber` flag.

This is a fix for #60 and inspired by the fix for #99.